### PR TITLE
allow the caller to update the filter gain

### DIFF
--- a/imu.go
+++ b/imu.go
@@ -219,3 +219,9 @@ func (v Quaternion) GetWorldAccel() [3]float64 {
 
 	return World
 }
+
+// Change Beta, the filter gain. The default is 0.1, but can be adjusted to
+// sqrt(3/4)*averageGyroError (average of all axes)
+func (v Quaternion) SetFilterGain(newBeta float64) {
+  beta = newBeta
+}


### PR DESCRIPTION
Beta can be set lower on good-quality gyroscopes for a more responsive
filter. Allow the user to update it.